### PR TITLE
Update spelling of intelligentLinking in defaults

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,7 +38,7 @@ const DEFAULT_SETTINGS: DEVONlinkSettings = {
 	DEVONlinkIconColor: 'DEVONthink-logo-blue',
 	maximumRelatedItemsSetting: 10,
 	relatedItemsPrefixSetting: "- ",
-	linkTypeSetting: "Intelligent Linking"
+	linkTypeSetting: "intelligentLinking"
 }
 
 export default class DEVONlinkPlugin extends Plugin {


### PR DESCRIPTION
It looks like the default setting for links is `Intelligent Linking`, but the AppleScript [is checking for `intelligentLinking` instead](https://github.com/undees/DEVONlink-obsidian/blob/master/main.ts#L154). This might cause the "Insert related items" feature not to work on the first usage of the plugin (but [explicitly setting the value in the plugin options](https://github.com/undees/DEVONlink-obsidian/blob/master/main.ts#L366) works fine).

This PR updates the default value to `intelligentLinking` to match the rest of the plugin.

Thanks for this plugin, btw! I've long been seeking an easy way to toggle between Obsidian and DEVONthink views of my notes.